### PR TITLE
Better icon CSS on mobile

### DIFF
--- a/src/assets/styles/home.scss
+++ b/src/assets/styles/home.scss
@@ -171,8 +171,11 @@
             "grid-paragraphs";
     }
 
-    .grid-icons {
-        justify-self: end;
+    .icons {
+        display: flex;
+        justify-content: space-between;
+        width: 75%;
+        margin: 0 auto;
     }
 
     .picture {
@@ -189,6 +192,10 @@
 
     .grid-footer {
         margin-top: 0;
+    }
+
+    .grid-langs-theme {
+        grid-template-areas: "grid-langs grid-theme";
     }
 
     .main-title {


### PR DESCRIPTION
Before
<img width="282" alt="image" src="https://github.com/user-attachments/assets/357b437c-b3b1-4804-ab95-e13c3156bb56" />


After
<img width="279" alt="image" src="https://github.com/user-attachments/assets/570b2b2a-ae3b-4890-8f5d-606e219e8060" />
