### PR TITLE
Add sitemap.xml and Link header for agent-readiness

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -50,5 +50,10 @@ from = "/*"
 to = "/"
 status = 200
 
+[[headers]]
+for = "/*"
+[headers.values]
+Link = "</sitemap.xml>; rel=\"sitemap\""
+
 [[plugins]]
 package = "netlify-plugin-debug-cache"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://saleh.sh/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,29 +5,4 @@
         <changefreq>monthly</changefreq>
         <priority>1.0</priority>
     </url>
-    <url>
-        <loc>https://saleh.sh/about</loc>
-        <changefreq>yearly</changefreq>
-        <priority>0.5</priority>
-    </url>
-    <url>
-        <loc>https://saleh.sh/30</loc>
-        <changefreq>yearly</changefreq>
-        <priority>0.5</priority>
-    </url>
-    <url>
-        <loc>https://saleh.sh/nycmarathon24</loc>
-        <changefreq>yearly</changefreq>
-        <priority>0.5</priority>
-    </url>
-    <url>
-        <loc>https://saleh.sh/nycmarathon25</loc>
-        <changefreq>yearly</changefreq>
-        <priority>0.5</priority>
-    </url>
-    <url>
-        <loc>https://saleh.sh/bday25</loc>
-        <changefreq>yearly</changefreq>
-        <priority>0.5</priority>
-    </url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://saleh.sh/</loc>
+        <changefreq>monthly</changefreq>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://saleh.sh/about</loc>
+        <changefreq>yearly</changefreq>
+        <priority>0.5</priority>
+    </url>
+    <url>
+        <loc>https://saleh.sh/30</loc>
+        <changefreq>yearly</changefreq>
+        <priority>0.5</priority>
+    </url>
+    <url>
+        <loc>https://saleh.sh/nycmarathon24</loc>
+        <changefreq>yearly</changefreq>
+        <priority>0.5</priority>
+    </url>
+    <url>
+        <loc>https://saleh.sh/nycmarathon25</loc>
+        <changefreq>yearly</changefreq>
+        <priority>0.5</priority>
+    </url>
+    <url>
+        <loc>https://saleh.sh/bday25</loc>
+        <changefreq>yearly</changefreq>
+        <priority>0.5</priority>
+    </url>
+</urlset>


### PR DESCRIPTION
## Summary
Follow-up to #80 to address the failures from [isitagentready.com](https://isitagentready.com/) and reach Level 1 ("Basic Web Presence").

- Add `public/sitemap.xml` listing only `/`. The other Vue Router routes (`/about`, `/30`, `/nycmarathonNN`, `/bdayNN`) are intentionally unlisted "secret" URLs meant for direct link-sharing only.
- Reference the sitemap from `public/robots.txt` via a `Sitemap:` directive.
- Add a global `Link: </sitemap.xml>; rel="sitemap"` response header in `netlify.toml`.

External-redirect-only paths (`/cv`, `/resume`, `/spiderman`, etc.) are intentionally **not** in the sitemap — they're shortcuts to off-site content, not canonical pages on this site.

Other agent-readiness checks (MCP server cards, A2A agent cards, OAuth discovery, x402, etc.) are out of scope for a static personal site and were skipped.

## Test plan
- [ ] After deploy, `curl https://saleh.sh/sitemap.xml` returns the XML listing only `https://saleh.sh/`.
- [ ] `curl https://saleh.sh/robots.txt` shows the new `Sitemap:` line.
- [ ] `curl -I https://saleh.sh/` shows the `Link: </sitemap.xml>; rel="sitemap"` header.
- [ ] Re-run the isitagentready.com scan — expect Level 1, with `sitemap` and `linkHeaders` checks now passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)