### PR TITLE
Add /blog and /posts redirects to saleh.soy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,6 +52,12 @@ status = 302
 force = true
 
 [[redirects]]
+from = "/posts"
+to = "https://saleh.soy/"
+status = 302
+force = true
+
+[[redirects]]
 from = "/*"
 to = "/"
 status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -46,6 +46,12 @@ status = 302
 force = true
 
 [[redirects]]
+from = "/blog"
+to = "https://saleh.soy/"
+status = 302
+force = true
+
+[[redirects]]
 from = "/*"
 to = "/"
 status = 200


### PR DESCRIPTION
## Summary
Two Netlify 302s pointing at the blog:

| From | To |
|------|-----|
| `/blog` | `https://saleh.soy/` |
| `/posts` | `https://saleh.soy/` |

## Test plan
- [ ] `curl -I https://saleh.sh/blog` → 302, `location: https://saleh.soy/`.
- [ ] `curl -I https://saleh.sh/posts` → 302, `location: https://saleh.soy/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)