### PR TITLE
Add Playwright smoke suite + modernize CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,21 +2,23 @@ name: Build
 
 on:
   push:
-    branches:
-      - master
-      - '*'
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-      - name: Set up Node.js 14
-        uses: actions/setup-node@v1  # Set up Node.js with a specified version
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14'
-      - name: Install
-        run: npm ci
-      - name: Build
-        run: npm run build
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npx playwright install chromium --with-deps
+      - run: npm test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,16 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - run: npx vue-cli-service lint --no-fix
       - run: npm run build
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npx playwright install chromium --with-deps
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+      - run: npx playwright install-deps chromium
+        if: steps.pw-cache.outputs.cache-hit == 'true'
       - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ npm-debug.log*
 
 # Local Netlify folder
 .netlify
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@kazupon/vue-i18n-loader": "^0.3.0",
+        "@playwright/test": "^1.59.1",
         "@vue/cli-plugin-babel": "^4.5.15",
         "@vue/cli-plugin-eslint": "^4.5.15",
         "@vue/cli-service": "^4.5.19",
@@ -2308,6 +2309,22 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@soda/friendly-errors-webpack-plugin": {
@@ -13486,6 +13503,38 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pnp-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "not ie <= 10"
   ],
   "engines": {
-    "npm": "8.0.0",
-    "node": "14.19.3"
+    "npm": ">=10.0.0",
+    "node": ">=20.0.0"
   },
   "overrides": {
     "fsevents": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "test": "playwright test",
     "clean": "rm -rf node_modules/ dist/",
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'"
   },
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@kazupon/vue-i18n-loader": "^0.3.0",
+    "@playwright/test": "^1.59.1",
     "@vue/cli-plugin-babel": "^4.5.15",
     "@vue/cli-plugin-eslint": "^4.5.15",
     "@vue/cli-service": "^4.5.19",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+const {defineConfig, devices} = require('@playwright/test');
+
+module.exports = defineConfig({
+    testDir: './tests',
+    timeout: 20000,
+    fullyParallel: false,
+    workers: 1,
+    reporter: 'list',
+    use: {
+        baseURL: 'http://localhost:8080',
+        headless: true,
+    },
+    webServer: {
+        command: 'npm run serve',
+        url: 'http://localhost:8080',
+        reuseExistingServer: !process.env.CI,
+        timeout: 60000,
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: {...devices['Desktop Chrome']},
+        },
+    ],
+});

--- a/tests/features.spec.js
+++ b/tests/features.spec.js
@@ -1,0 +1,154 @@
+const {test, expect} = require('@playwright/test');
+
+test('language switcher: click AR flips to RTL + Arabic', async ({page}) => {
+    await page.goto('/');
+    await expect(page.locator('.lang-item.selected-lang')).toHaveText(
+        'English',
+    );
+    await page.locator('.lang-item').filter({hasText: 'عربي'}).click();
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    await expect(page).toHaveTitle('صالح الغصون');
+    await expect(page.locator('#grid-main')).toHaveClass(/right-to-left/);
+    await expect(page.locator('body')).toHaveClass(/font-amiri/);
+    await expect(page.locator('.grid-paragraphs p').first()).toContainText(
+        'أنا من السعودية',
+    );
+});
+
+test('language switch triggers slide animation on #grid-main', async ({
+    page,
+}) => {
+    await page.goto('/');
+    await page.locator('.lang-item').filter({hasText: 'عربي'}).click();
+    // animation class lives on #grid-main for ~500ms
+    await expect(page.locator('#grid-main')).toHaveClass(/section-anim-rtl/);
+    const animName = await page.evaluate(
+        () => getComputedStyle(document.getElementById('grid-main')).animationName,
+    );
+    expect(animName).toBe('sectionAnimRTL');
+});
+
+test('space bar cycles language', async ({page}) => {
+    await page.goto('/');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await page.keyboard.press('Space');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    await page.keyboard.press('Space');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+});
+
+test('t toggles theme on home', async ({page}) => {
+    await page.goto('/');
+    await expect(page.locator('body')).toHaveClass(/light-theme/);
+    await page.keyboard.press('t');
+    await expect(page.locator('body')).toHaveClass(/dark-theme/);
+    await page.keyboard.press('t');
+    await expect(page.locator('body')).toHaveClass(/light-theme/);
+});
+
+test('t toggles theme on sub-pages (regression: shortcuts must be global)', async ({
+    page,
+}) => {
+    await page.goto('/');
+    await expect(page.locator('body')).toHaveClass(/light-theme/);
+    // client-side nav via the 'a b o u t' chord (what a real user does)
+    for (const k of ['a', 'b', 'o', 'u', 't']) {
+        await page.keyboard.press(k);
+    }
+    await expect(page).toHaveURL('/about');
+    // toggle theme and assert it flips from whatever state it's in
+    const before = await page.evaluate(() =>
+        document.body.classList.contains('dark-theme') ? 'dark' : 'light',
+    );
+    await page.keyboard.press('y');
+    await page.keyboard.press('t');
+    await page.waitForFunction((before) => {
+        const isDark = document.body.classList.contains('dark-theme');
+        return (before === 'light' && isDark) || (before === 'dark' && !isDark);
+    }, before);
+});
+
+test('f toggles font on home', async ({page}) => {
+    await page.goto('/');
+    await expect(page.locator('body')).toHaveClass(/font-rubik/);
+    await page.keyboard.press('f');
+    await expect(page.locator('body')).toHaveClass(/font-ibm/);
+    await page.keyboard.press('f');
+    await expect(page.locator('body')).toHaveClass(/font-rubik/);
+});
+
+test('"a b o u t" chord navigates to /about', async ({page}) => {
+    await page.goto('/');
+    for (const k of ['a', 'b', 'o', 'u', 't']) {
+        await page.keyboard.press(k);
+    }
+    await expect(page).toHaveURL('/about');
+});
+
+test('"3 0" chord navigates to /30', async ({page}) => {
+    await page.goto('/');
+    await page.keyboard.press('3');
+    await page.keyboard.press('0');
+    await expect(page).toHaveURL('/30');
+});
+
+test('"2 5" chord navigates to /nycmarathon25', async ({page}) => {
+    await page.goto('/');
+    await page.keyboard.press('2');
+    await page.keyboard.press('5');
+    await expect(page).toHaveURL('/nycmarathon25');
+});
+
+test('Vuex persist: theme survives reload', async ({page}) => {
+    await page.goto('/');
+    await page.keyboard.press('t');
+    await expect(page.locator('body')).toHaveClass(/dark-theme/);
+
+    const persisted = await page.evaluate(() =>
+        localStorage.getItem('~~saleh~~-1.6'),
+    );
+    expect(persisted).toContain('"theme":"dark"');
+
+    await page.reload();
+    await expect(page.locator('body')).toHaveClass(/dark-theme/);
+});
+
+// On Vue 2 main this fails: Home.vue registers a store.watch in created() that
+// manipulates #grid-main, and Vue 2 doesn't auto-dispose component-bound
+// watchers. After navigating to /about and switching language, the watcher
+// fires against a removed DOM node and throws.
+//
+// The SvelteKit rewrite (PR #84) addresses this by wiring DOM-mutating
+// effects through onMount(state.subscribe(...)) in +layout.svelte — the
+// subscription is disposed when the layout unmounts.
+//
+// Unmark this test (`test(` instead of `test.fixme(`) once the rewrite lands.
+test.fixme('lang change on sub-pages does not throw', async ({page}) => {
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+    page.on('console', (m) => {
+        if (m.type() === 'error') errors.push(m.text());
+    });
+    await page.goto('/');
+    for (const k of ['a', 'b', 'o', 'u', 't']) {
+        await page.keyboard.press(k);
+    }
+    await expect(page).toHaveURL('/about');
+    await page.keyboard.press('Space');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    expect(errors).toEqual([]);
+});
+
+test('Vuex persist: language survives reload', async ({page}) => {
+    await page.goto('/');
+    await page.locator('.lang-item').filter({hasText: 'عربي'}).click();
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    await expect(page.locator('#grid-main')).toHaveClass(/right-to-left/);
+
+    await page.reload();
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    await expect(page).toHaveTitle('صالح الغصون');
+    await expect(page.locator('body')).toHaveClass(/font-amiri/);
+    await expect(page.locator('#grid-main')).toHaveClass(/right-to-left/);
+});

--- a/tests/routes.spec.js
+++ b/tests/routes.spec.js
@@ -1,0 +1,66 @@
+const {test, expect} = require('@playwright/test');
+
+test('home renders', async ({page}) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle('Saleh Alghusson');
+    await expect(page.locator('.main-title')).toContainText("I'm");
+    await expect(page.locator('.main-title')).toContainText('Saleh');
+    await expect(page.locator('.grid-paragraphs p').first()).toContainText(
+        'I am from Saudi Arabia',
+    );
+    await expect(page.locator('img.picture')).toBeVisible();
+    await expect(page.locator('.grid-footer')).toContainText('updated');
+});
+
+test('about renders with back link and git hash', async ({page}) => {
+    await page.goto('/about');
+    await expect(page.locator('body')).toContainText('-back');
+    await expect(page.locator('body')).toContainText('commit:');
+});
+
+test('/30 renders the Thirty page', async ({page}) => {
+    await page.goto('/30');
+    await expect(page.locator('body')).toContainText('Soft invite');
+    await expect(page.locator('body')).toContainText('Prospect park');
+});
+
+test('/nycmarathon24 renders', async ({page}) => {
+    await page.goto('/nycmarathon24');
+    await expect(page.locator('body')).toContainText('2024 NYC Marathon');
+});
+
+test('/nycmarathon25 renders', async ({page}) => {
+    await page.goto('/nycmarathon25');
+    await expect(page.locator('body')).toContainText('Letter to Shareholders');
+    await expect(page.locator('body')).toContainText('27769');
+});
+
+test('/bday25 renders', async ({page}) => {
+    await page.goto('/bday25');
+    await expect(page.locator('body')).toContainText('celebrate my birthday');
+});
+
+test('unknown path redirects to home', async ({page}) => {
+    await page.goto('/this-does-not-exist');
+    await expect(page).toHaveURL('/');
+    await expect(page.locator('.main-title')).toBeVisible();
+});
+
+test('smile icon renders inside p2 via i18n-t slot', async ({page}) => {
+    await page.goto('/');
+    const p2 = page.locator('.grid-paragraphs p').nth(1);
+    await expect(p2).toContainText('Away from the keyboard');
+    // FA5 uses data-icon="smile", FA6 uses "face-smile" — match both
+    await expect(p2.locator('svg[data-icon*="smile"]')).toBeVisible();
+});
+
+test('no console errors on home', async ({page}) => {
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+    page.on('console', (m) => {
+        if (m.type() === 'error') errors.push(m.text());
+    });
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
Salvages the high-value pieces of the closed #79 (Vue 3 upgrade) before retiring it: the Playwright smoke suite, `playwright.config.js`, and a modernized CI workflow. The Vue 3 migration code itself is dropped — saleh.sh is going to SvelteKit (#84).

The tests are stack-agnostic. Selectors target user-facing class names (`.lang-item`, `#grid-main`, `.grid-paragraphs`, `.main-title`, body theme classes, the `~~saleh~~-1.6` localStorage key) which the SvelteKit rewrite plan explicitly preserves. They become the feature-parity verification harness for that rewrite.

## What's included
- `tests/features.spec.js` (12 tests) — language switcher, RTL, theme/font shortcuts, chord navigation, vuex-persist round-tripping.
- `tests/routes.spec.js` (9 tests) — every route renders, smile icon present in `p2`, no console errors, unknown path falls back to home.
- `playwright.config.js` — `npm run serve` on `:8080`, chromium only.
- `@playwright/test ^1.59.1` in devDeps, `npm test` script.
- `.github/workflows/build.yml` modernized — Node 14/actions@v1 → Node 20/actions@v4. Now runs lint + build + Playwright on every PR with concurrency cancellation. Playwright browsers cached via `actions/cache@v4` so the chromium download only happens when the lockfile changes.
- `engines` bumped to `node >= 20.0.0` / `npm >= 10.0.0` to match the runtime.
- `.gitignore` updated for Playwright artifact dirs.

## Adjustments from #79's version
- localStorage key `~~saleh~~-2.0` → `~~saleh~~-1.6` (matches what's in production today and what the SvelteKit plan preserves).
- Smile-icon selector `[data-icon="face-smile"]` → `[data-icon*="smile"]` (matches both FA5's `smile` and FA6's `face-smile`).
- One test marked `test.fixme` with an explanatory comment: `lang change on sub-pages does not throw` — documents a real Vue 2 regression in `Home.vue`'s `store.watch`. The SvelteKit rewrite's `onMount(state.subscribe(...))` pattern (Step 5.3 of #84) fixes it. Plan #84 Step 10 includes "unfixme this and verify it passes" as a required verification.

## Verification
Locally: 20 pass, 1 fixme'd, 0 fail against current Vue 2 main. CI green.

## Test plan
- [x] CI runs lint, build, and the Playwright suite — green on every push to this branch.